### PR TITLE
Fix all issues with 1.5.0

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -54,9 +54,9 @@ internal class Program
         }
 
         if(!autoUpdate) {
-            Console.WriteLine("Download master cores list file from github? (This will overwrite your current file) [y/n]:");
+            Console.WriteLine("Download master cores list file from github? (This will overwrite your current file) [y/n]: (default is y)");
             response = Console.ReadKey(false).Key;
-            if (response == ConsoleKey.Y) {
+            if (response == ConsoleKey.Y || response == ConsoleKey.Enter) {
                 await DownloadCoresFile(cores);
             }
         } else {

--- a/Updater.cs
+++ b/Updater.cs
@@ -290,6 +290,7 @@ public class PocketCoreUpdater
                     break;
             }
         }
+        zip.Dispose();
         if(extraFiles) {
             _writeMessage("Additional were installed. They can be found in: ");
             _writeMessage(extraPath);

--- a/Updater.cs
+++ b/Updater.cs
@@ -277,7 +277,7 @@ public class PocketCoreUpdater
                     var a = entry.ExternalAttributes;
                     var lowerByte = (byte)(a & 0x00FF);
                     var attributes = (FileAttributes)lowerByte;
-                    if (!attributes.HasFlag(FileAttributes.Directory)) {
+                    if (!(attributes.HasFlag(FileAttributes.Directory) || entry.FullName.Substring(entry.FullName.Length -1) != "/" || entry.FullName.Substring(entry.FullName.Length - 1) != @"\")) {
                         if (!File.Exists(destination)) {
                             new System.IO.FileInfo(destination).Directory.Create();
                         }

--- a/Updater.cs
+++ b/Updater.cs
@@ -277,7 +277,7 @@ public class PocketCoreUpdater
                     var a = entry.ExternalAttributes;
                     var lowerByte = (byte)(a & 0x00FF);
                     var attributes = (FileAttributes)lowerByte;
-                    if (!(attributes.HasFlag(FileAttributes.Directory) || entry.FullName.Substring(entry.FullName.Length -1) != "/" || entry.FullName.Substring(entry.FullName.Length - 1) != @"\")) {
+                    if (!(attributes.HasFlag(FileAttributes.Directory) || entry.FullName.Substring(entry.FullName.Length -1) == "/" || entry.FullName.Substring(entry.FullName.Length - 1) == @"\")) {
                         if (!File.Exists(destination)) {
                             new System.IO.FileInfo(destination).Directory.Create();
                         }

--- a/pocket_updater.sln
+++ b/pocket_updater.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "pocket_updater", "pocket_updater.csproj", "{88615FF5-4649-4DD0-B721-449269388A88}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{88615FF5-4649-4DD0-B721-449269388A88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88615FF5-4649-4DD0-B721-449269388A88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88615FF5-4649-4DD0-B721-449269388A88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88615FF5-4649-4DD0-B721-449269388A88}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E762A40A-D6F5-4D10-B9D2-9310E95944B6}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- when I push just enter at the download Y/N prompt, the app crashes with an exception instead of using "Y" as default

- after that it crashes with "Unhandled exception. System.IO.IOException: The process cannot access the file '...\pocket_updater._win\core.zip' because it is being used by another process." - i have no antivirus except the default win10 defender

- also the lunar lander core has to seem a broken zip entry for the assets folder... also crashe

- also added a visual studio solution file